### PR TITLE
Command line arguments for FrameRipper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.png
 *.pyc
 *.mov
+src/arc/*
+src/good_stuff/*
 
 test.py
 videos/*

--- a/src/FrameRipper.py
+++ b/src/FrameRipper.py
@@ -6,18 +6,27 @@ from filter_finder import FilterFinder
 from image_filter import ImageFilter
 from autocropper import AutoCropper
 
+from argparse import ArgumentParser
+
 # Frame Ripper Script
 
 __author__ = 'Steve'
 
 # Rips frames and creates seperate directories for each individual video
 def main():
-    frames_needed = 1000
+    parser = ArgumentParser()
+    parser.add_argument('videospath', 
+                        help='path to videos to rip and crop frames')
+    parser.add_argument('--framecount', nargs='?', 
+                        help='number of frames to rip for each video')
+    args = parser.parse_args()
+    
+    frames_needed = int(args.framecount if args.framecount is not None else 500)
     generator = FilterFinder()
     skateboard_filter = ImageFilter(generator.get_default_filters())
     autocropper = AutoCropper(blur_amt=1000, padding=40, pre_crop=0, img_stride=3)
     
-    for video_file_name in get_video_files():
+    for video_file_name in get_video_files(args.videospath):
         cap = cv2.VideoCapture(video_file_name)
         video_folder_name = video_file_name + 'data'
         create_data_directory(video_folder_name)
@@ -25,7 +34,7 @@ def main():
         total_frame_count = get_total_frames(cap)
         frames_to_use = get_random_frame_numbers(total_frame_count, frames_needed)
         for i, frame in enumerate(frames_to_use):
-            name = './{}/image{}.jpg'.format(video_folder_name, i)
+            name = os.path.join(video_folder_name, 'image{}.jpg'.format(i))
             save_random_frame(cap, frame, name, skateboard_filter, autocropper)
             
         cap.release()
@@ -37,7 +46,7 @@ def get_video_files(video_path = 'Videos'):
     video_list = []
     
     for entry in os.listdir(video_path):
-        video_list.append(video_path + '/' + entry)
+        video_list.append(os.path.join(video_path, entry))
     return video_list
 
 def create_data_directory(video_folder_name):

--- a/src/FrameRipper.py
+++ b/src/FrameRipper.py
@@ -12,10 +12,10 @@ __author__ = 'Steve'
 
 # Rips frames and creates seperate directories for each individual video
 def main():
-    frames_needed = 100
+    frames_needed = 1000
     generator = FilterFinder()
     skateboard_filter = ImageFilter(generator.get_default_filters())
-    autocropper = AutoCropper(blur_amt=1000, padding=30, pre_crop=0)
+    autocropper = AutoCropper(blur_amt=1000, padding=40, pre_crop=0, img_stride=3)
     
     for video_file_name in get_video_files():
         cap = cv2.VideoCapture(video_file_name)


### PR DESCRIPTION
allow the frameripper to be "more" generic, by having videos path (and optionally frame ripping count) passed as command line arguments

use like:
> cd src
> python FrameRipper.py VIDEOSPATH [--framecount FRAMECOUNT] 

Arguments:
- `videospath` - path to videos to rip and crop frames
- `framecount` *(optional)* - number of frames to rip for each video